### PR TITLE
make `items` optional in SetQueueOptions definition

### DIFF
--- a/MusicKit/MusicKit.SetQueueOptions.d.ts
+++ b/MusicKit/MusicKit.SetQueueOptions.d.ts
@@ -14,7 +14,7 @@ declare namespace MusicKit {
     /**
      * The media items used to set a music player's playback queue.
      */
-    items: descriptor[];
+    items?: descriptor[];
     /**
      * The parameters used to set a music player's playback queue.
      */


### PR DESCRIPTION
the documentation seems to have some internal conflict about whether or not `items` is necessary, but in usage it appears to be optional.

Here, `items` is not defined as optional for `MusicKit.SetQueueOptions`: https://developer.apple.com/documentation/musickitjs/musickit/setqueueoptions

But here, setQueue is called without `items`: https://developer.apple.com/documentation/musickitjs/accessing_musickit_features_using_javascript#3004833

^^ If that URL doesn't work, this is the example:

```js
// "You can initialize a playback queue by using the setQueue method,
//  either with individual media items, or with an album or playlist."
//
// "To set a queue using an album's URL:"

let music = MusicKit.getInstance();
let url = 'https://itunes.apple.com/us/album/hamilton-original-broadway-cast-recording/1025210938';
music.setQueue({ url: url }).then(function(queue) {
  // Queue is instantiated and set on music player.
});
```

And in usage it seems to work.
